### PR TITLE
fix for IE

### DIFF
--- a/audio-js.css
+++ b/audio-js.css
@@ -40,6 +40,7 @@ so you can upgrade to newer versions easier. */
   -o-transition: opacity 0.5s linear;
   -ms-transition: opacity 0.5s linear;
   transition: opacity 0.5s linear;
+	font-size: 0;
 }
 
 .ajs-hide {


### PR DESCRIPTION
Believe it or not, IE breaks the controls. Turning down font size (apart from where it's explicitly turned back up) fixes it.
